### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,9 +1,9 @@
 Authors
 -------
 
-Flask-OAIServer is developed for use in `Invenio <http://invenio-software.org>`_ digital library software.
+Flask-OAIServer is developed for use in `Invenio <http://inveniosoftware.org>`_ digital library software.
 
-Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
+Contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_
 
 Contributors
 ^^^^^^^^^^^^

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,1 +1,1 @@
-See <http://invenio-software.org/wiki/Development/Contributing> for now.
+See <http://inveniosoftware.org/wiki/Development/Contributing> for now.

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     url='http://github.com/inveniosoftware/flask-oaiserver/',
     license='BSD',
     author='Invenio collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description='Flask-OAIServer allows you to quickly add an OAI-PMH server'
                 'to your Flask application.',
     long_description=open('README.rst').read(),


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
